### PR TITLE
enable notValidWithSchema for chai tests

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,11 +12,20 @@ module.exports = function (chai, utils) {
     })
   });
 
+    chai.Assertion.addMethod('notValidWithSchema', function (schema, msg) {
+        const obj = this._obj;
+        const schemas = Array.isArray(schema) ? schema : [schema];
+        schemas.forEach(function(sch_test){
+            var valid = chai.ajv.validate(sch_test, obj);
+            assert(!valid, chai.ajv.errorsText());
+        })
+    });
+
   assert.validWithSchema = function (val, exp, msg) {
     new chai.Assertion(val, msg).to.be.validWithSchema(exp);
   };
 
   assert.notValidWithSchema = function (val, exp, msg) {
-    new chai.Assertion(val, msg).to.not.be.validWithSchema(exp);
+    new chai.Assertion(val, msg).to.be.validWithSchema(exp);
   };
 }

--- a/tests/index.js
+++ b/tests/index.js
@@ -7,7 +7,13 @@ var schema = require('./schemas/complex.json');
 chai.ajv.addSchema(schema, "test_schema");
 
 describe("use mocha", function(){
-  it("invalidates with a borken schema", function(){
+  it("invalidates with a broken schema", function(){
     expect({}).to.validWithSchema("test_schema");
   })
+})
+
+describe("negative testing", function(){
+    it("'notValidWithSchema' validates with a broken schema", function(){
+        expect({}).to.notValidWithSchema("test_schema");
+    })
 })


### PR DESCRIPTION
Because 'validWithSchema' was not working as expected with a negative expect statement (see issue created), this allowed using negative testing with 'notValidWithSchema' instead.